### PR TITLE
Fixed footer link to CDS

### DIFF
--- a/index.html
+++ b/index.html
@@ -489,7 +489,7 @@
       </ul>
         <ul class="toc-footer">
             <li><a href='https://github.com/cdr-register/register'>CDR Register on Github</a></li>
-            <li><a href='https://consumerdatastandards.org.au'>Consumer Data Standards</a></li>
+            <li><a href='https://consumerdatastandards.gov.au'>Consumer Data Standards</a></li>
             <li><a href='includes/swagger/swagger.json'>Swagger (JSON)</a></li>
             <li><a href='includes/swagger/swagger.yaml'>Swagger (YAML)</a></li>
         </ul>


### PR DESCRIPTION
Link to CDS in the footer is no longer valid and is presenting an invalid certificate. Seems to have been changed to a different domain.

`https://consumerdatastandards.org.au` -> `https://consumerdatastandards.gov.au`