### PR TITLE
fix(index.html): add missing quotes and comma in response JSON

### DIFF
--- a/index.html
+++ b/index.html
@@ -1375,7 +1375,7 @@ Accept: application/json
    "application_type":"web",
    "id_token_signed_response_alg":"PS256",
    "id_token_encrypted_response_alg":"RSA-OAEP",
-   "id_token_encrypted_response_enc:"A256GCM",
+   "id_token_encrypted_response_enc":"A256GCM",
    "request_object_signing_alg":"PS256",
    "software_statement":…
 }
@@ -1530,7 +1530,7 @@ Content-Type: application/json
    "application_type":"web",
    "id_token_signed_response_alg":"PS256",
    "id_token_encrypted_response_alg":"RSA-OAEP",
-   "id_token_encrypted_response_enc:"A256GCM",
+   "id_token_encrypted_response_enc":"A256GCM",
    "request_object_signing_alg":"PS256",
    "software_statement":"…",
    "legal_entity_id": "3B0B0A7B-3E7B-4A2C-9497-E357A71D07C7",
@@ -1546,7 +1546,7 @@ Content-Type: application/json
    "jwks_uri": "https://www.mockcompany.com.au/jwks",
    "revocation_uri": "https://www.mockcompany.com.au/revocation",
    "recipient_base_uri": "https://www.mockcompany.com.au",
-   "sector_identifier_uri": "https://www.mockcompany.com.au/sector_identifier"
+   "sector_identifier_uri": "https://www.mockcompany.com.au/sector_identifier",
    "software_id": "740C368F-ECF9-4D29-A2EA-0514A66B0CDE",
    "software_roles": "data-recipient-software-product",
    "scope":


### PR DESCRIPTION
The format JSON response for `/register` is broken.